### PR TITLE
Working listen count tracking

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -98,6 +98,10 @@ export default function App() {
       if (track.url !== currentTrackUrl) {
         setCurrentTrackUrl(track.url);
         setIsPlaying(true);
+        fetch("/api/track/tags/incrementListenCount", {
+          method: "POST",
+          body: JSON.stringify({ trackUrl: track.url }),
+        });
       } else if (isPlaying) {
         pause();
       } else {

--- a/app/routes/api.track.tags.incrementListenCount.ts
+++ b/app/routes/api.track.tags.incrementListenCount.ts
@@ -1,0 +1,23 @@
+import type { ActionFunctionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+
+import { getTags, setTags } from "../util/s3.server";
+
+/** Increment a track's `listenCount` metadata */
+export async function action({ request }: ActionFunctionArgs) {
+  const { trackUrl } = await request.json();
+  const trackKey = trackUrl.replace(
+    `https://${process.env.STORAGE_BUCKET}.s3.${process.env.STORAGE_REGION}.amazonaws.com/`,
+    "",
+  );
+  const { TagSet } = await getTags(trackKey);
+  const listenCountTag = TagSet?.find((t) => t.Key === "listenCount");
+  let listenCount =
+    (listenCountTag?.Value && Number(listenCountTag.Value)) || 0;
+
+  listenCount += 1;
+
+  await setTags(trackKey, [{ Key: "listenCount", Value: String(listenCount) }]);
+
+  return json({ ok: true });
+}

--- a/app/util/files.ts
+++ b/app/util/files.ts
@@ -4,6 +4,7 @@ import { fromUrl } from "id3js";
 
 export type Track = {
   url: string;
+  tagFetch: Promise<Array<{ Key: string; Value: string }> | undefined>;
   title: string;
   trackNum: number;
   lastModified: number | null;
@@ -115,6 +116,12 @@ const getAlbumIds = (files: Files) =>
   Object.values(files).flatMap((albums) =>
     Object.values(albums).map((album) => album.id),
   );
+
+export const getAllTracks = (files: Files) => {
+  return Object.values(files).flatMap((albums) =>
+    Object.values(albums).flatMap((album) => album.tracks),
+  );
+};
 
 /** Get most recently uploaded albums */
 export const getAlbumIdsByRecent = (files: Files): Album[] => {


### PR DESCRIPTION
This works, but we need a better way to
1. Pull the `listenCount` during the initial pull
2. Track the current listen count locally